### PR TITLE
enable to work on empty line.

### DIFF
--- a/autoload/textobj/ruby.vim
+++ b/autoload/textobj/ruby.vim
@@ -63,7 +63,8 @@ endfunction
 function! s:search_block(block) "{{{
     let pos = getpos('.')
     try
-        let [syntax, head_indent, head] = s:search_head(a:block, indent('.'))
+        let indent = getline('.') == '' ? cindent('.') : indent('.')
+        let [syntax, head_indent, head] = s:search_head(a:block, indent)
         call setpos('.', pos)
         let tail = s:search_tail(a:block, head_indent, syntax)
         return ['V', head, tail]


### PR DESCRIPTION
`#\%` is the place of your cursor.

``` ruby
def foo
  do_something
#\%
  do_something
end
```
# before

Type `dir`, vim says 'block is not found.'.
# after

Type `dir`, removes inner `def` block.

``` ruby
def foo
end
```
